### PR TITLE
ha-wis-stt: Fix deprecation warning from Home Assistant

### DIFF
--- a/custom_components/wis-stt/__init__.py
+++ b/custom_components/wis-stt/__init__.py
@@ -1,7 +1,6 @@
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.typing import HomeAssistantType
 
 DOMAIN = "wis-stt"
 
@@ -18,5 +17,5 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry):
 async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry):
     return await hass.config_entries.async_unload_platforms(config_entry, PLATFORMS)
 
-async def async_update_options(hass: HomeAssistantType, entry):
+async def async_update_options(hass: HomeAssistant, entry):
     await hass.config_entries.async_reload(entry.entry_id)


### PR DESCRIPTION
This fixes a deprecation warning from Home Assistant of a method that will stop working in the 05.2025 release.